### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import importlib.metadata
 import importlib.util
 import sys
 import types
@@ -1260,6 +1261,18 @@ async def run_single_query(prompt: str, quiet: bool = False, verbose: bool = Fal
                 emitter.set_interactive_mode(False, False)
 
 
+def _get_version() -> str:
+    """Get the package version.
+
+    Returns:
+        Version string (e.g., "0.1.1")
+    """
+    try:
+        return importlib.metadata.version("osdu-agent")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Create CLI argument parser."""
     parser = argparse.ArgumentParser(
@@ -1455,6 +1468,11 @@ Examples:
         "--verbose",
         action="store_true",
         help="Show detailed execution tree with tool calls (single-query mode only)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
     )
 
     return parser


### PR DESCRIPTION
## Summary

This change adds version reporting functionality to the CLI by implementing a `--version` flag that displays the package version.

## Key Modifications

### Version Retrieval Function
- Added `_get_version()` helper function that uses `importlib.metadata.version()` to retrieve the installed package version for "osdu-agent"
- Includes error handling to return "unknown" if the package metadata is not found (`PackageNotFoundError`)

### CLI Argument Parser
- Added `--version` argument to the argument parser using `action="version"`
- The version string format follows the standard pattern: `%(prog)s {version}` (e.g., "osdu-agent 0.1.1")

### Import Addition
- Added `import importlib.metadata` to support the new version retrieval functionality